### PR TITLE
accountsテーブルからユーザー名削除

### DIFF
--- a/app/assets/stylesheets/devise_account.scss
+++ b/app/assets/stylesheets/devise_account.scss
@@ -16,7 +16,7 @@
     padding: 20px 26px;
 
     @media only screen and (min-height: 511px) {
-      margin: calc((100vh - 511px) / 2) auto;
+      margin: calc((100vh - 401px) / 2) auto;
     }
 
     @media only screen and (max-height: 510px) {

--- a/app/assets/stylesheets/devise_registrations.scss
+++ b/app/assets/stylesheets/devise_registrations.scss
@@ -4,7 +4,7 @@
 
 .box {
   width: 350px;
-  min-height: 500px;
+  min-height: 440px;
   margin: 60px auto;
   padding: 20px 26px;
 

--- a/app/controllers/accounts/registrations_controller.rb
+++ b/app/controllers/accounts/registrations_controller.rb
@@ -80,7 +80,7 @@ class Accounts::RegistrationsController < Devise::RegistrationsController
   private
 
   def check_guest
-    return unless resource.username == 'ゲストユーザー'
+    return unless resource.email == 'guest@com'
 
     flash[:alert] = 'ゲストユーザーの変更・削除はできません。'
     render 'show', layout: 'devise_account'

--- a/app/controllers/accounts/sessions_controller.rb
+++ b/app/controllers/accounts/sessions_controller.rb
@@ -20,10 +20,10 @@ class Accounts::SessionsController < Devise::SessionsController
   # end
 
   def new_guest
-    account = Account.find_by(username: 'ゲストユーザー')
+    account = Account.find_by(email: 'guest@com')
     if !account
-      Account.create(username: 'ゲストユーザー', password: 'guestuser123', email: 'guest@com')
-      account = Account.find_by(username: 'ゲストユーザー')
+      Account.create(password: 'guestuser123', email: 'guest@com')
+      account = Account.find_by(email: 'guest@com')
       sign_in account
       Category.create(name: 'カテゴリなし', account_id: current_account.id, is_default: true)
     else

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -4,24 +4,20 @@ class Account < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
-         authentication_keys: [:username]
+         :recoverable, :rememberable, :validatable
+        #  authentication_keys: [:username]
 
-  def self.find_first_by_auth_conditions(warden_conditions)
-    conditions = warden_conditions.dup
-    if login = conditions.delete(:login)
-      # 認証の条件式を変更する
-      where(conditions).where(['username = :value', { value: username }]).first
-    else
-      where(conditions).first
-    end
-  end
+  # def self.find_first_by_auth_conditions(warden_conditions)
+  #   conditions = warden_conditions.dup
+  #   if login = conditions.delete(:login)
+  #     # 認証の条件式を変更する
+  #     where(conditions).where(['email = :value', { value: email }]).first
+  #   else
+  #     where(conditions).first
+  #   end
+  # end
 
-  validates_uniqueness_of :username
-  validates_presence_of :username
-  validates :username, length: { maximum: 12 }
-
-  def email_changed?
-    false
-  end
+  # def email_changed?
+  #   false
+  # end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,12 +5,6 @@
       <h2>マイデータ更新</h2>
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "ui form"}) do |f| %> 
       <%= render "devise/shared/error_messages", resource: resource %>
-
-      <div class="field">
-        <%= f.label :username, 'ユーザー名' %>
-        <%= f.text_field :username, autofocus: true, autocomplete: "username" %>
-      </div>
-
       <div class="field">
         <%= f.label :email, 'メールアドレス' %>
         <%= f.email_field :email, autofocus: true, autocomplete: "email" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,11 +5,6 @@
       <h1>新規登録</h1>
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: "ui form"}) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
-        <div class="field box-username">
-          <%= f.label :username ,'ユーザー名'%>
-          <%= f.text_field :username, autofocus: true, autocomplete: "username" %>
-        </div>
-
         <div class="field">
           <%= f.label :email, 'メールアドレス' %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email" %>

--- a/app/views/devise/registrations/show.html.erb
+++ b/app/views/devise/registrations/show.html.erb
@@ -12,12 +12,6 @@
         <%= link_to '編集', edit_account_registration_path, { class: 'ui yellow-button button right' } %>
       <% end %>
       <div class="output">
-        <label for="username">ユーザー名</label>
-        <div class="el">
-          <%= current_account.username %>
-        </div>
-      </div>
-      <div class="output">
         <label for="email">メールアドレス</label>
         <div class="el">
           <%= current_account.email %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -11,8 +11,8 @@
       <h1>ログイン</h1>
       <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: {class: "ui form"} ) do |f| %>
         <div class="field box-username">
-          <%= f.label :username ,'ユーザー名'%>
-          <%= f.text_field :username, autofocus: true, autocomplete: "username"%>
+          <%= f.label :email ,'メールアドレス'%>
+          <%= f.text_field :email, autofocus: true, autocomplete: "email"%>
         </div>
         <div class="field box-password">
           <div class="column-left"><%= f.label :password , 'パスワード' %></div>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -2,7 +2,6 @@ ja:
   activerecord:
     attributes:
       account:
-        username: ユーザー名
         confirmation_sent_at: パスワード確認送信時刻
         confirmation_token: パスワード確認用トークン
         confirmed_at: パスワード確認時刻
@@ -26,8 +25,6 @@ ja:
         unconfirmed_email: 未確認Eメール
         unlock_token: ロック解除用トークン
         updated_at: 更新日
-    models:
-      account: ユーザ
   devise:
     confirmations:
       confirmed: メールアドレスが確認できました。

--- a/db/migrate/20200922155227_remove_username_from_accounts.rb
+++ b/db/migrate/20200922155227_remove_username_from_accounts.rb
@@ -1,0 +1,9 @@
+class RemoveUsernameFromAccounts < ActiveRecord::Migration[6.0]
+  def up
+    remove_column :accounts, :username, :string
+  end
+
+  def down
+    add_column :accounts, :username, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_15_042715) do
+ActiveRecord::Schema.define(version: 2020_09_22_155227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,7 +23,6 @@ ActiveRecord::Schema.define(version: 2020_09_15_042715) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "username"
     t.index ["email"], name: "index_accounts_on_email", unique: true
     t.index ["reset_password_token"], name: "index_accounts_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
アプリ内でユーザー同士のコミュニケーションがないため、ユーザー名は不要と判断した。